### PR TITLE
Specify qt4 in build_qt.sh

### DIFF
--- a/build_qt.sh
+++ b/build_qt.sh
@@ -3,5 +3,5 @@
 echo "cd libgambatte && scons"
 (cd libgambatte && scons) || exit
 
-echo "cd gambatte_qt && qmake && make"
-(cd gambatte_qt && qmake && make)
+echo "cd gambatte_qt && qmake -qt=qt4 && make"
+(cd gambatte_qt && qmake -qt=qt4 && make)


### PR DESCRIPTION
Fixes compilation on systems where the default qt version is 5+.

At this point there appears to be no real "upstream" remaining, but yours is the most recognizable name I see in the forks, so I figure this is a good place to send the fix. If you have a better target in mind, feel free to let me know.